### PR TITLE
Bump paho-mqtt version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,14 @@ authors = [
 ]
 description = "The IoT integrator IoTknit."
 readme = "README.rst"
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 keywords = ["IoT", "integration", "MQTT"]
 license = {text = "MIT License"}
 classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "paho-mqtt>=1.6.1"
+    "paho-mqtt>=2.0.0"
 ]
 #version = "0.0.1"
 dynamic = ["version"]

--- a/src/iotknit/thingconnector.py
+++ b/src/iotknit/thingconnector.py
@@ -12,7 +12,7 @@ import paho.mqtt.client as mqtt
 class ThingConnector():
     def __init__(self, mqtt_host):
         # TODO: add username/password/tsl
-        self.client = mqtt.Client()
+        self.client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1)
         self.client.connect(mqtt_host)  # need to connect before subscribe
         # TODO: implement re-connect
         self.mqtt_host = mqtt_host


### PR DESCRIPTION
Version 2.0 of paho-mqtt introduced user-callback versioning to improve consistency and better support MQTTv5. To use the previous version, it must be specified during client creation `mqttc = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1)`.

Additionally, older Python versions are no longer supported, with the minimum requirement now being Python 3.7. You can find more details in the [migration guide](https://eclipse.dev/paho/files/paho.mqtt.python/html/migrations.html).

I opened the pull request in a way that allows maintainers to add edits in case you discover that more changes are needed.